### PR TITLE
Add support for Noise Cancelling and Wind mode

### DIFF
--- a/Client/CommandSerializer.cpp
+++ b/Client/CommandSerializer.cpp
@@ -4,6 +4,7 @@ constexpr unsigned char ESCAPED_BYTE_SENTRY = 61;
 constexpr unsigned char ESCAPED_60 = 44;
 constexpr unsigned char ESCAPED_61 = 45;
 constexpr unsigned char ESCAPED_62 = 46;
+constexpr unsigned int MAX_STEPS_WH_1000_XM3 = 19;
 
 namespace CommandSerializer
 {
@@ -152,14 +153,32 @@ namespace CommandSerializer
 		return ret;
 	}
 
-	Buffer serializeNcAndAsmSetting(NC_ASM_EFFECT ncAsmEffect, NC_ASM_SETTING_TYPE ncAsmSettingType, unsigned int unk, ASM_SETTING_TYPE asmSettingType, ASM_ID asmId, unsigned char asmLevel)
+	NC_DUAL_SINGLE_VALUE getDualSingleForAsmLevel(unsigned char asmLevel)
+	{
+		NC_DUAL_SINGLE_VALUE val = NC_DUAL_SINGLE_VALUE::OFF;
+		if (asmLevel > MAX_STEPS_WH_1000_XM3)
+		{
+			throw std::runtime_error("Exceeded max steps");
+		}
+		else if (asmLevel == 1)
+		{
+			val = NC_DUAL_SINGLE_VALUE::SINGLE;
+		}
+		else if (asmLevel == 0)
+		{
+			val = NC_DUAL_SINGLE_VALUE::DUAL;
+		}
+		return val;
+	}
+
+	Buffer serializeNcAndAsmSetting(NC_ASM_EFFECT ncAsmEffect, NC_ASM_SETTING_TYPE ncAsmSettingType, ASM_SETTING_TYPE asmSettingType, ASM_ID asmId, unsigned char asmLevel)
 	{
 		Buffer ret;
 		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::NCASM_SET_PARAM));
 		ret.push_back(static_cast<unsigned char>(NC_ASM_INQUIRED_TYPE::NOISE_CANCELLING_AND_AMBIENT_SOUND_MODE));
 		ret.push_back(static_cast<unsigned char>(ncAsmEffect));
 		ret.push_back(static_cast<unsigned char>(ncAsmSettingType));
-		ret.push_back(static_cast<unsigned char>(unk));
+		ret.push_back(static_cast<unsigned char>(getDualSingleForAsmLevel(asmLevel)));
 		ret.push_back(static_cast<unsigned char>(asmSettingType));
 		ret.push_back(static_cast<unsigned char>(asmId));
 		ret.push_back(asmLevel);

--- a/Client/CommandSerializer.h
+++ b/Client/CommandSerializer.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <stdexcept>
 
-
+constexpr unsigned int MINIMUM_VOICE_FOCUS_STEP = 2;
 
 namespace CommandSerializer
 {
@@ -35,7 +35,8 @@ namespace CommandSerializer
 	Buffer packageDataForBt(const Buffer& src, DATA_TYPE dataType, unsigned int seqNumber);
 
 	Message unpackBtMessage(const Buffer& src);
-	//Probably set seqNumber to zero
-	Buffer serializeNcAndAsmSetting(NC_ASM_EFFECT ncAsmEffect, NC_ASM_SETTING_TYPE ncAsmSettingType, unsigned int unk, ASM_SETTING_TYPE asmSettingType, ASM_ID asmId, unsigned char asmLevel);
+
+	NC_DUAL_SINGLE_VALUE getDualSingleForAsmLevel(unsigned char asmLevel);
+	Buffer serializeNcAndAsmSetting(NC_ASM_EFFECT ncAsmEffect, NC_ASM_SETTING_TYPE ncAsmSettingType, ASM_SETTING_TYPE asmSettingType, ASM_ID asmId, unsigned char asmLevel);
 }
 

--- a/Client/Constants.h
+++ b/Client/Constants.h
@@ -55,6 +55,13 @@ enum class ASM_ID : char
 	VOICE = 1
 };
 
+enum class NC_DUAL_SINGLE_VALUE : char
+{
+	OFF = 0,
+	SINGLE = 1,
+	DUAL = 2
+};
+
 enum class COMMAND_TYPE : char
 {
 	NCASM_SET_PARAM = 104

--- a/Client/GUI_Impls/CrossPlatformGUI.cpp
+++ b/Client/GUI_Impls/CrossPlatformGUI.cpp
@@ -155,7 +155,15 @@ void CrossPlatformGUI::_drawASMControls()
 
 		bool sliderActive = ImGui::IsItemActive();
 
-		ImGui::Checkbox("Focus on Voice", &focusOnVoice);
+		if (asmLevel >= MINIMUM_VOICE_FOCUS_STEP)
+		{
+			ImGui::Checkbox("Focus on Voice", &focusOnVoice);
+		}
+		else
+		{
+			ImGui::Text("Focus on Voice isn't enabled on this level.");
+		}
+		
 
 		if (sentAsmLevel != asmLevel || sentFocusOnVoice != focusOnVoice)
 		{
@@ -168,7 +176,6 @@ void CrossPlatformGUI::_drawASMControls()
 					return this->_bt.sendCommand(CommandSerializer::serializeNcAndAsmSetting(
 						ncAsmEffect,
 						NC_ASM_SETTING_TYPE::LEVEL_ADJUSTMENT,
-						0,
 						ASM_SETTING_TYPE::LEVEL_ADJUSTMENT,
 						asmId,
 						asmLevel


### PR DESCRIPTION
Previously the headphones always let the lowest level of ambient sound in, even on level 0. Now the app correctly enables the noise cancelling modes. Closes #14 