### PR TITLE
Add option to turn off NC and ambient sound

### DIFF
--- a/Client/CommandSerializer.cpp
+++ b/Client/CommandSerializer.cpp
@@ -4,7 +4,7 @@ constexpr unsigned char ESCAPED_BYTE_SENTRY = 61;
 constexpr unsigned char ESCAPED_60 = 44;
 constexpr unsigned char ESCAPED_61 = 45;
 constexpr unsigned char ESCAPED_62 = 46;
-constexpr unsigned int MAX_STEPS_WH_1000_XM3 = 19;
+constexpr int MAX_STEPS_WH_1000_XM3 = 19;
 
 namespace CommandSerializer
 {
@@ -153,7 +153,7 @@ namespace CommandSerializer
 		return ret;
 	}
 
-	NC_DUAL_SINGLE_VALUE getDualSingleForAsmLevel(unsigned char asmLevel)
+	NC_DUAL_SINGLE_VALUE getDualSingleForAsmLevel(char asmLevel)
 	{
 		NC_DUAL_SINGLE_VALUE val = NC_DUAL_SINGLE_VALUE::OFF;
 		if (asmLevel > MAX_STEPS_WH_1000_XM3)
@@ -171,7 +171,7 @@ namespace CommandSerializer
 		return val;
 	}
 
-	Buffer serializeNcAndAsmSetting(NC_ASM_EFFECT ncAsmEffect, NC_ASM_SETTING_TYPE ncAsmSettingType, ASM_SETTING_TYPE asmSettingType, ASM_ID asmId, unsigned char asmLevel)
+	Buffer serializeNcAndAsmSetting(NC_ASM_EFFECT ncAsmEffect, NC_ASM_SETTING_TYPE ncAsmSettingType, ASM_SETTING_TYPE asmSettingType, ASM_ID asmId, char asmLevel)
 	{
 		Buffer ret;
 		ret.push_back(static_cast<unsigned char>(COMMAND_TYPE::NCASM_SET_PARAM));

--- a/Client/CommandSerializer.h
+++ b/Client/CommandSerializer.h
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include "Exceptions.h"
 
-constexpr unsigned int MINIMUM_VOICE_FOCUS_STEP = 2;
+constexpr int MINIMUM_VOICE_FOCUS_STEP = 2;
 
 namespace CommandSerializer
 {
@@ -37,7 +37,7 @@ namespace CommandSerializer
 
 	Message unpackBtMessage(const Buffer& src);
 
-	NC_DUAL_SINGLE_VALUE getDualSingleForAsmLevel(unsigned char asmLevel);
-	Buffer serializeNcAndAsmSetting(NC_ASM_EFFECT ncAsmEffect, NC_ASM_SETTING_TYPE ncAsmSettingType, ASM_SETTING_TYPE asmSettingType, ASM_ID asmId, unsigned char asmLevel);
+	NC_DUAL_SINGLE_VALUE getDualSingleForAsmLevel(char asmLevel);
+	Buffer serializeNcAndAsmSetting(NC_ASM_EFFECT ncAsmEffect, NC_ASM_SETTING_TYPE ncAsmSettingType, ASM_SETTING_TYPE asmSettingType, ASM_ID asmId, char asmLevel);
 }
 

--- a/Client/GUI_Impls/CrossPlatformGUI.cpp
+++ b/Client/GUI_Impls/CrossPlatformGUI.cpp
@@ -215,7 +215,7 @@ void CrossPlatformGUI::_drawASMControls()
 		//We're not waiting, and there's no command in the air, so we can evaluate sending a new command
 		else if (sentAsmLevel != asmLevel || sentFocusOnVoice != focusOnVoice || sentAmbientSoundControl != ambientSoundControl)
 		{
-			auto ncAsmEffect = sliderActive ? NC_ASM_EFFECT::ADJUSTMENT_IN_PROGRESS : NC_ASM_EFFECT::ADJUSTMENT_COMPLETION;
+			auto ncAsmEffect = sliderActive ? NC_ASM_EFFECT::ADJUSTMENT_IN_PROGRESS : ambientSoundControl ? NC_ASM_EFFECT::ADJUSTMENT_COMPLETION : NC_ASM_EFFECT::OFF;
 			auto asmId = focusOnVoice ? ASM_ID::VOICE : ASM_ID::NORMAL;
 			lastAsmLevel = asmLevel == -1 ? lastAsmLevel : asmLevel;
 			asmLevel = ambientSoundControl ? lastAsmLevel : -1;

--- a/Client/GUI_Impls/CrossPlatformGUI.cpp
+++ b/Client/GUI_Impls/CrossPlatformGUI.cpp
@@ -164,16 +164,13 @@ void CrossPlatformGUI::_drawASMControls()
 
 	if (ImGui::CollapsingHeader("Ambient Sound Mode   ", ImGuiTreeNodeFlags_DefaultOpen))
 	{
-
 		ImGui::Checkbox("Ambient Sound Control", &ambientSoundControl);
 
 		if (ambientSoundControl)
 		{
-
 			ImGui::Text("Control ambient sound for your %ss", this->_connectedDevice.name.c_str());
 
 			ImGui::SliderInt("Ambient Sound Level", &asmLevel, 0, 19);
-
 		}
 
 		bool sliderActive = ImGui::IsItemActive();
@@ -231,7 +228,7 @@ void CrossPlatformGUI::_drawASMControls()
 					asmId,
 					asmLevel
 				));
-				});
+			});
 			sentAsmLevel = asmLevel;
 			sentFocusOnVoice = focusOnVoice;
 			sentAmbientSoundControl = ambientSoundControl;

--- a/Client/GUI_Impls/CrossPlatformGUI.cpp
+++ b/Client/GUI_Impls/CrossPlatformGUI.cpp
@@ -152,18 +152,29 @@ void CrossPlatformGUI::_drawDeviceDiscovery()
 
 void CrossPlatformGUI::_drawASMControls()
 {
+	static bool ambientSoundControl = true;
+	static bool sentAmbientSoundControl = ambientSoundControl;
 	static bool focusOnVoice = false;
 	static bool sentFocusOnVoice = focusOnVoice;
 	static int asmLevel = 0;
+	static int lastAsmLevel = asmLevel;
 	static int sentAsmLevel = asmLevel;
 	//Don't show if the command only takes a few frames to send
 	static int commandLinger = 0;
 
 	if (ImGui::CollapsingHeader("Ambient Sound Mode   ", ImGuiTreeNodeFlags_DefaultOpen))
 	{
-		ImGui::Text("Control ambient sound for your %ss", this->_connectedDevice.name.c_str());
 
-		ImGui::SliderInt("Ambient Sound Level", &asmLevel, 0, 19);
+		ImGui::Checkbox("Ambient Sound Control", &ambientSoundControl);
+
+		if (ambientSoundControl)
+		{
+
+			ImGui::Text("Control ambient sound for your %ss", this->_connectedDevice.name.c_str());
+
+			ImGui::SliderInt("Ambient Sound Level", &asmLevel, 0, 19);
+
+		}
 
 		bool sliderActive = ImGui::IsItemActive();
 
@@ -205,10 +216,12 @@ void CrossPlatformGUI::_drawASMControls()
 			}
 		}
 		//We're not waiting, and there's no command in the air, so we can evaluate sending a new command
-		else if (sentAsmLevel != asmLevel || sentFocusOnVoice != focusOnVoice)
+		else if (sentAsmLevel != asmLevel || sentFocusOnVoice != focusOnVoice || sentAmbientSoundControl != ambientSoundControl)
 		{
 			auto ncAsmEffect = sliderActive ? NC_ASM_EFFECT::ADJUSTMENT_IN_PROGRESS : NC_ASM_EFFECT::ADJUSTMENT_COMPLETION;
 			auto asmId = focusOnVoice ? ASM_ID::VOICE : ASM_ID::NORMAL;
+			lastAsmLevel = asmLevel == -1 ? lastAsmLevel : asmLevel;
+			asmLevel = ambientSoundControl ? lastAsmLevel : -1;
 
 			this->_sendCommandFuture.setFromAsync([=]() {
 				return this->_bt.sendCommand(CommandSerializer::serializeNcAndAsmSetting(
@@ -218,9 +231,10 @@ void CrossPlatformGUI::_drawASMControls()
 					asmId,
 					asmLevel
 				));
-			});
+				});
 			sentAsmLevel = asmLevel;
 			sentFocusOnVoice = focusOnVoice;
+			sentAmbientSoundControl = ambientSoundControl;
 		}
 	}
 }

--- a/Client/GUI_Impls/CrossPlatformGUI.cpp
+++ b/Client/GUI_Impls/CrossPlatformGUI.cpp
@@ -171,18 +171,18 @@ void CrossPlatformGUI::_drawASMControls()
 			ImGui::Text("Control ambient sound for your %ss", this->_connectedDevice.name.c_str());
 
 			ImGui::SliderInt("Ambient Sound Level", &asmLevel, 0, 19);
+
+			if (asmLevel >= MINIMUM_VOICE_FOCUS_STEP)
+			{
+				ImGui::Checkbox("Focus on Voice", &focusOnVoice);
+			}
+			else
+			{
+				ImGui::Text("Focus on Voice isn't enabled on this level.");
+			}
 		}
 
 		bool sliderActive = ImGui::IsItemActive();
-
-		if (asmLevel >= MINIMUM_VOICE_FOCUS_STEP)
-		{
-			ImGui::Checkbox("Focus on Voice", &focusOnVoice);
-		}
-		else
-		{
-			ImGui::Text("Focus on Voice isn't enabled on this level.");
-		}
 
 		if (this->_sendCommandFuture.ready())
 		{


### PR DESCRIPTION
This fixes #18. After taking a look over bluetooth messages, found out that ambient sound control is turned off when sending vol=-1.

The only problem I faced is when checking and, after, unchecking the box. It returns a "Invalid checksum!". Same happens when do it at "Focus on Voice" checkbox, so I think that's maybe a problem with XM4's (and not my changes), as other people said in #27.

I tested it in XM4's and Windows. Hope it helps! :)